### PR TITLE
Workaround for a doc escaping issue in svd2rust

### DIFF
--- a/nrf52832/src/lib.rs
+++ b/nrf52832/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = "Peripheral access API for NRF52 microcontrollers (generated using svd2rust v0.13.1)\n\nYou can find an overview of the API [here].\n\n[here]: https://docs.rs/svd2rust/0.13.1/svd2rust/#peripheral-api"]
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![allow(non_camel_case_types)]
 #![no_std]
 #![feature(untagged_unions)]

--- a/nrf52840/src/lib.rs
+++ b/nrf52840/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = "Peripheral access API for NRF52840 microcontrollers (generated using svd2rust v0.13.1)\n\nYou can find an overview of the API [here].\n\n[here]: https://docs.rs/svd2rust/0.13.1/svd2rust/#peripheral-api"]
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![allow(non_camel_case_types)]
 #![no_std]
 #![feature(untagged_unions)]

--- a/update.sh
+++ b/update.sh
@@ -15,6 +15,11 @@ for chip in nrf52832 nrf52840 ; do
   form -i lib.rs -o src
   rm lib.rs
   cargo fmt
+
+  # workaround for https://github.com/rust-embedded/svd2rust/issues/232
+  grep -v 'deny(warnings)' src/lib.rs > lib.rs
+  mv lib.rs src/lib.rs
+
   rustfmt build.rs
   cd ..
 done


### PR DESCRIPTION
Refs: https://github.com/rust-embedded/svd2rust/issues/232

This is the same technique used in nrf51:
https://github.com/therealprof/nrf51/commit/131678562067a062a93adb124abc8f3795d4cc41